### PR TITLE
 Linki do ceneo.pl w serwisach Polskiej Grupa Press

### DIFF
--- a/easylistpolish/easylistpolish_general_hide.txt
+++ b/easylistpolish/easylistpolish_general_hide.txt
@@ -19,3 +19,4 @@
 ##a[href^="http://wlbetathome.adsrv.eacdn.com"]
 ##div[onclick^="update_ad("]
 ##li[data-title="Sponsorowane"]
+##.componentsPromotionsOffers__list


### PR DESCRIPTION
Linki do ceneo.pl w serwisach Polskiej Grupa Press tych serwisów jest tak dużo, że proponuje to wrzucić do general_hide

https://kurierlubelski.pl/mistrzowie-motoryzacji-oto-pierwsze-motocykle-zgloszone-do-akcji-motocykl-roku-dodaj-zdjecie-twojego-motocykla/ar/c4-14201725

![image](https://user-images.githubusercontent.com/49181769/61056307-63e76400-a3f3-11e9-8c7c-0d9a57584926.png)
