### PR TITLE
kierunekenergetyka.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1057,3 +1057,4 @@ infoprzasnysz.com##.zodnbrutw-image
 gorzow24.pl##a[href="https://www.gowork.pl/"]
 gorzow24.pl##.gml
 e-kg.pl##.custompartners
+kierunekenergetyka.pl,kieruneksurowce.pl,kierunekchemia.pl##.col-sm-6 > .ads-title + div


### PR DESCRIPTION
-[kierunekenergetyka.pl](https://www.kierunekenergetyka.pl)-[kieruneksurowce.pl](https://www.kieruneksurowce.pl)-[kierunekchemia.pl](https://www.kierunekchemia.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/kierunekenergetyka.pl.png)