### PR TITLE
24gliwice.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -631,3 +631,4 @@ _reklamy_$domain=chojna24.pl
 ||zyciezamoscia.pl^*^kamienie_small
 ||zyciezamoscia.pl^*^niewygodne2.
 ||zyciezamoscia.pl^*^niezalezna.
+^show-baners.php?$script,domain=24gliwice.pl


### PR DESCRIPTION
-[24gliwice.pl](https://www.24gliwice.pl/wiadomosci/nareszcie-po-kilku-miesiacach-przerwy-drogowcy-wracaja-do-remontu-ulicy-michalowskiego/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/24gliwice.pl.png)