### PR TITLE
bydgoszcz24.pl-popup-linux-only

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -972,3 +972,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+bydgoszcz24.pl##.topLayer


### PR DESCRIPTION
-[bydgoszcz24.pl-popup-linux-only](https://bydgoszcz24.pl/pl/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/bydgoszcz24.pl-popup-linux-only.png)