### PR TITLE
o2.pl-WP

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1012,3 +1012,5 @@ cypr24.eu##div[class^="g-single a-"]
 wylecz.to##div[data-event="slotSeen"]
 olx.pl##.inter-box_ad-detail_boxing
 elektroda.pl##a[target="_blank"]:not([href*="elektroda.pl"]) > img[alt]
+o2.pl#?#div:-abp-has(> img[data-testid^="ad-placeholder-"])
+o2.pl##div[class$="container"]


### PR DESCRIPTION
-[o2.pl-WP](https://www.o2.pl/informacje/wenezuela-oskarza-kolumbie-o-inwazje-na-morzu-6506778774825089a)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/o2.pl.png)