### PR TITLE
radiojura.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1004,3 +1004,4 @@ slupca.pl##.a-220
 elektroda.pl##[onclick*="this.target='_blank';"]
 elektroda.pl##[onclick*="naviboxEvent"]
 elektroda.pl##[onclick*="'Click'"]
+radiojura.pl##.sec-promo


### PR DESCRIPTION
https://www.radiojura.pl/miejskie-przedszkole-nr-6-na-groszu-wznowilo-dzialalnosci.html

![image](https://user-images.githubusercontent.com/58596052/82039190-eb9d9f00-96a4-11ea-8ee9-4067a391f78e.png)
