### PR TITLE
warzywapolowe.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1260,3 +1260,5 @@ radiowrzesnia.pl##div[class^="g-dyn a-"]
 medexpress.pl##.adver_box
 tyna.info.pl##.top-bar-content a
 plock.fm##div[class^="g-single a-"]
+warzywapolowe.pl##.td-a-rec
+warzywapolowe.pl##a[onclick^="trackOutboundLink('"]


### PR DESCRIPTION
-[warzywapolowe.pl](https://www.warzywapolowe.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/warzywapolowe.pl.png)