### PR TITLE
polsatnews.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1260,3 +1260,4 @@ radiowrzesnia.pl##div[class^="g-dyn a-"]
 medexpress.pl##.adver_box
 tyna.info.pl##.top-bar-content a
 plock.fm##div[class^="g-single a-"]
+polsatsport.pl,polsatnews.pl##a[href^="https://redefineadpl."]


### PR DESCRIPTION
-[polsatnews.pl](https://www.polsatnews.pl)-[polsatsport.pl](https://www.polsatsport.pl/wiadomosc/2020-07-01/polska-czechy-transmisja-drugiego-sparingu-w-polsacie-sport/?ref=slider)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/polsatnews.pl.png)