### PR TITLE
pogonsportnet.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -908,3 +908,4 @@ _banner_$domain=dzisiajwgliwicach.pl
 ||plonskwsieci.pl^upload^piekarczykmaly.
 ||tyna.info.pl^*^puz-online700.
 ||tyna.info.pl^*^nowy-sandomierz-net-
+||ibb.co^$image,domain=pogonsportnet.pl


### PR DESCRIPTION
-[pogonsportnet.pl](http://pogonsportnet.pl/news/kozulj-prezes-mroczek-powinien-skupic-sie-na-swoim-klubie)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/pogonsportnet.pl.png)