### PR TITLE
pomorskifutbol.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -908,3 +908,5 @@ _banner_$domain=dzisiajwgliwicach.pl
 ||plonskwsieci.pl^upload^piekarczykmaly.
 ||tyna.info.pl^*^puz-online700.
 ||tyna.info.pl^*^nowy-sandomierz-net-
+^baneryJPG^$domain=pomorskifutbol.pl
+^bannery^$domain=pomorskifutbol.pl

--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1260,3 +1260,4 @@ radiowrzesnia.pl##div[class^="g-dyn a-"]
 medexpress.pl##.adver_box
 tyna.info.pl##.top-bar-content a
 plock.fm##div[class^="g-single a-"]
+pomorskifutbol.pl##a[href^="https://stsplaffiliates-api."]


### PR DESCRIPTION
-[pomorskifutbol.pl](http://pomorskifutbol.pl/news_11426_PKO-Ekstraklasa_-Rakow-Czestochowa-3-2-Arka-Gdynia.html)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/pomorskifutbol.pl.png)