### PR TITLE
niebezpiecznik.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1304,3 +1304,4 @@ poprostupycha.com.pl###reklama-wlasna
 mragowo24.info##.show-adv
 opowiecie.info##.a-widget
 starachowicka.pl##div[class^="g-dyn a-"]
+niebezpiecznik.pl##a[href^="https://niebezpiecznik.pl/r"][href$=".php"] > img:not([width])


### PR DESCRIPTION
-[niebezpiecznik.pl](https://niebezpiecznik.pl/post/bialorus-odcina-sie-od-swiatowego-internetu/?similarpost)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/niebezpiecznik.pl.png)