### PR TITLE
radioq.fm-popup

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -947,3 +947,4 @@ _banner_$domain=dzisiajwgliwicach.pl
 ||lwowecki.info^*^biuro_rachunkowe_
 ||lwowecki.info^*^bielak-fotowoltaika.
 ^banery^$domain=eglos.pl
+||radioq.fm^*^jquery.gafancybox.$script


### PR DESCRIPTION
-[radioq.fm-popup](http://radioq.fm/wiadomosci/2300-ponad-1200-litrow-nielegalnego-alkoholu-zabezpieczyli-policjanci-z-kutna)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/radioq.fm-popup.png)