### PR TITLE
swarzedz24.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1416,3 +1416,5 @@ hej.mielec.pl##.topLayer
 fight24.pl###add_produkt
 fight24.pl##a[href^="https://www.sfd.pl/"]
 goniecpolski.nl###execphp-2
+swarzedz24.pl###media_image-314
+swarzedz24.pl###media_image-324


### PR DESCRIPTION
-[swarzedz24.pl](https://swarzedz24.pl/znowu-wiecej-zakazen-covid-19-juz-13-przypadkow-w-gminie-swarzedz/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/swarzedz24.pl.png)