### PR TITLE
sportowepodhale.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1057,3 +1057,4 @@ _baner_$domain=dogosfera.pl
 ||lokalna24.pl^*^debowe_wzgorze.
 ||rrs24.net^*^marta_ubezpieczenia.
 _baner.$domain=osowa24.pl
+^ad^$domain=sportowepodhale.pl


### PR DESCRIPTION
-[sportowepodhale.pl](https://sportowepodhale.pl/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/sportowepodhale.pl.png)