### PR TITLE
poscigi.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1382,3 +1382,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+poscigi.pl##.bsaProContainerNew


### PR DESCRIPTION
https://poscigi.pl/mocno-wieje-zielonogorscy-strazacy-jezdza-do-powalonych-drzew/

![image](https://user-images.githubusercontent.com/58596052/95956509-b38abb80-0dfe-11eb-8f70-7d757e512e47.png)
