### PR TITLE
swoszowice.org.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1410,3 +1410,7 @@ zeglarski.info##.add-box
 lubiehrubie.pl##.lubie-widget
 300polityka.pl##.ad
 300polityka.pl##.banner
+swoszowice.org.pl##a[href^="https://carline.com.pl/"]
+swoszowice.org.pl##a[href^="https://www.autodoc.pl/"]
+swoszowice.org.pl##a[href^="http://www.unison.pl/"]
+swoszowice.org.pl###text-7


### PR DESCRIPTION
-[swoszowice.org.pl](https://swoszowice.org.pl/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/swoszowice.org.pl.png)