### PR TITLE
teraz-wilanow.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1437,3 +1437,5 @@ telewizor.eu###block
 techpolska.pl##a[href^="https://www.ceneo.pl/"]
 telewizjaleszno.pl###vlog-module-0-0
 telko.in##.custom-html p > script + a
+teraz-wilanow.pl##div[id^="rev_slider_2_"]
+teraz-wilanow.pl##div[id^="rev_slider_1"]


### PR DESCRIPTION
-[teraz-wilanow.pl](http://teraz-wilanow.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/teraz-wilanow.pl.png)