### PR TITLE
tvnakarte.eu

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1526,3 +1526,4 @@ wilanownews.pl###main center > a
 wilanownews.pl###text-2
 conamokotowie.pl##.menu__ul + .a-re + a
 conamokotowie.pl##.a-re+a:nth-of-type(1)
+tvnakarte.eu###jm-right .custom


### PR DESCRIPTION
-[tvnakarte.eu](https://tvnakarte.eu/index.php/aktualnosci/83-iti-neovision-zmiana-nazwy-na-canal-polska-s-a)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/tvnakarte.eu.png)