### PR TITLE
adservers: tvtoss.com + pocketads.pl

### DIFF
--- a/easylistpolish/easylistpolish_adservers.txt
+++ b/easylistpolish/easylistpolish_adservers.txt
@@ -13,3 +13,5 @@
 ||waytogrow.eu^$third-party
 ||waytogrow.pl^$third-party
 ||wtg-ads.com^$third-party
+||tvtoss.com
+||pocketAds.pl

--- a/easylistpolish/easylistpolish_adservers.txt
+++ b/easylistpolish/easylistpolish_adservers.txt
@@ -8,10 +8,10 @@
 ||incontext.pl^$third-party
 ||leadstar.pl^$third-party
 ||media.stsaff.pl^$third-party
+||pocketads.pl^$third-party
 ||reklamawadowice24.pl^$third-party
 ||rewords.pl^$third-party
+||tvtoss.com^$third-party
 ||waytogrow.eu^$third-party
 ||waytogrow.pl^$third-party
 ||wtg-ads.com^$third-party
-||tvtoss.com
-||pocketAds.pl


### PR DESCRIPTION
Serwery reklamowe na które trafiłem w różnych miejscach. `tvtoss` bezposrednio przekierowuje na reklamy, `pocketads` jest czasem używane na stronach wp. 