### PR TITLE
vetopedia.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -938,3 +938,5 @@ _banner_$domain=jagodnik.pl
 ^baner-$domain=cowwilanowie.pl
 ^banner_$domain=conamokotowie.pl
 ||iochota.pl^*^inline__1080942_
+||vetopedia.pl^*^vetid.
+||vetopedia.pl^*^newbanvetid.


### PR DESCRIPTION
-[vetopedia.pl](https://www.vetopedia.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/vetopedia.pl.png)