### PR TITLE
erw24.net

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1539,3 +1539,4 @@ uploaduj.com##a[href^="https://hotpay.pl"]
 uploaduj.com##a[href^="https://lead.network/"]
 ustrzyki24.pl##.ads-s
 vampirediaries.pl##td[onclick^="window.location"]
+erw24.net##section#gkZyczenia


### PR DESCRIPTION
https://erw24.net/wiadomosci/lodzkie/od-jutra-e-wizyty-w-zus-w-lodzkiem

![image](https://user-images.githubusercontent.com/58596052/98098159-4367d680-1e8e-11eb-84b8-f160ffc299b9.png)
