### PR TITLE
tojuzbylo.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -947,3 +947,4 @@ _reklamy_$domain=chojna24.pl
 -reklama-$domain=tv-pelplin.pl
 ^reklama-$domain=tv-pelplin.pl
 ^banners^$domain=otososnowiec.pl
+||emisja.contentstream.pl^$script,domain=tojuzbylo.pl


### PR DESCRIPTION
-[tojuzbylo.pl](https://tojuzbylo.pl/wiadomosc/bitwa-o-borujsk-ostatnia-szarza-polskiej-kawalerii)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/tojuzbylo.pl.png)