### PR TITLE
tylkonauka.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -947,3 +947,4 @@ _reklamy_$domain=chojna24.pl
 -reklama-$domain=tv-pelplin.pl
 ^reklama-$domain=tv-pelplin.pl
 ^banners^$domain=otososnowiec.pl
+||emisja.contentstream.pl^$script,domain=tylkonauka.pl


### PR DESCRIPTION
-[tylkonauka.pl](https://tylkonauka.pl/wiadomosc/futurolog-przewiduje-ze-do-2050-roku-ludzie-beda-mogli-porzucac-swoje-ciala-i-przenosic)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/tylkonauka.pl.png)