### PR TITLE
tylkomedycyna.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -947,3 +947,4 @@ _reklamy_$domain=chojna24.pl
 -reklama-$domain=tv-pelplin.pl
 ^reklama-$domain=tv-pelplin.pl
 ^banners^$domain=otososnowiec.pl
+||emisja.contentstream.pl^$script,domain=tylkomedycyna.pl


### PR DESCRIPTION
-[tylkomedycyna.pl](https://tylkomedycyna.pl/wiadomosc/naukowcy-znalezli-zwiazek-miedzy-otyloscia-slabym-wechem-0)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/tylkomedycyna.pl.png)