### PR TITLE
ddbrodnica.pl

### DIFF
--- a/easylistpolish/easylistpolish_adservers.txt
+++ b/easylistpolish/easylistpolish_adservers.txt
@@ -16,3 +16,4 @@
 ||waytogrow.eu^$third-party
 ||waytogrow.pl^$third-party
 ||wtg-ads.com^$third-party
+||netsalesmedia.pl^$third-party


### PR DESCRIPTION
https://www.ddbrodnica.pl/4678-przekroczyl-dozwolona-predkosc-w-terenie-zabudowanym-o-68-kmh

![image](https://user-images.githubusercontent.com/58596052/99948894-78bf6000-2d7a-11eb-8b53-b2fe66207c5d.png)
