### PR TITLE
losice.info

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1615,3 +1615,5 @@ zywiecinfo.pl##.carouselbanner
 starachowicki.eu##div[id^="bills_in_rotation_"] > a:not([href^="https://starachowicki.eu/"])
 konin24.info##.flex-list
 polanddaily.com##.wrapper img[style^="margin-bottom: 20px; max-width: 750px;"]
+losice.info##div.td-a-rec
+losice.info##.adni_widgets-2


### PR DESCRIPTION
https://losice.info/wkrecone-w-nigeryjski-przekret-stracily-28-i-90-tys-zl/

![image](https://user-images.githubusercontent.com/58596052/100738022-4692ab80-33d5-11eb-99ae-1f257b1b2336.png)
