### PR TITLE
grojec24.net + adservers

### DIFF
--- a/easylistpolish/easylistpolish_adservers.txt
+++ b/easylistpolish/easylistpolish_adservers.txt
@@ -17,3 +17,4 @@
 ||waytogrow.pl^$third-party
 ||wtg-ads.com^$third-party
 ||netsalesmedia.pl^$third-party
+||shopeneo.network^$third-party


### PR DESCRIPTION
https://www.grojec24.net/news-drogowcy-podsumowali-postepy-przy-budowie-nowej-trasy-grojec-warszawa,7289.html

![image](https://user-images.githubusercontent.com/58596052/100849026-3dabe380-3482-11eb-9216-1b4f6eed8d1f.png)
