### PR TITLE
infoszach.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1655,3 +1655,4 @@ kociewie24.pl##.dynamicAD
 infosokolka.pl###promoted-module
 narew.info##.toplayer
 zachodniemazowsze.info##[class^="g-single a-"]
+infoszach.pl##.mh-content-ad


### PR DESCRIPTION
https://infoszach.pl/2020/12/07/teclaf-i-rudzinska-mistrzami-polski-do-lat-20/

![image](https://user-images.githubusercontent.com/58596052/101471598-cecdff00-3947-11eb-8008-ea7a64504256.png)

w prawym menu jest tez reklama do ciuchow ale nad nia jest info ze to sponsor itp wiec nie blokuje