### PR TITLE
podobnestrony.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1655,3 +1655,4 @@ kociewie24.pl##.dynamicAD
 infosokolka.pl###promoted-module
 narew.info##.toplayer
 zachodniemazowsze.info##[class^="g-single a-"]
+podobnestrony.pl##a[href^="/external/2"] > picture


### PR DESCRIPTION
-[podobnestrony.pl](https://podobnestrony.pl/do/zalando.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/podobnestrony.pl.png)