### PR TITLE
motoocena.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1006,3 +1006,4 @@ _banner_$domain=chemiaibiznes.com.pl
 ^banery^$domain=co-slychac.pl
 ^reklama-$domain=tvciechanow.pl
 ^reklama-$domain=fleschmazowsza.com.pl
+^banners^$domain=motoocena.pl

--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1655,3 +1655,4 @@ kociewie24.pl##.dynamicAD
 infosokolka.pl###promoted-module
 narew.info##.toplayer
 zachodniemazowsze.info##[class^="g-single a-"]
+motoocena.pl##div[class^="banner-ad-"]


### PR DESCRIPTION
-[motoocena.pl](https://motoocena.pl/uwaga-vw-najbardziej-zadluzona-firma-swiata/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/motoocena.pl.png)