### PR TITLE
[redundant] portalwysokichplonow.pl##.ads_top_nav

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -444,7 +444,6 @@ rankinglekarzy.pl##.ads-slot
 kamienskie.info##.ads-subpage
 szokuje.pl##.ads-under_menu
 tarnowiak.pl##.adsRightBox
-portalwysokichplonow.pl##.ads_top_nav
 news-sport.pl##.adscounter
 pl.hospitalby.com##.adsense
 naszraciborz.pl##.adsense_title


### PR DESCRIPTION
Line 1573 contains specific hide filter, which is redundant to ##.ads_top_nav from EasyList, with domain(s) portalwysokichplonow.pl FILTER: portalwysokichplonow.pl##.ads_top_nav