### PR TITLE
[redundant] spottedlublin.pl##.g1-advertisement

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -720,7 +720,6 @@ slupca.pl##.g-4
 slupca.pl##.g-8
 debica.tv##.g-9
 topmejt.co.uk##.g-single
-spottedlublin.pl##.g1-advertisement
 skawinska.pl##.gaskad-single
 gazetacz.com.pl##.gazet-gorny-lewy
 gazetacz.com.pl##.gazet-gorny-prawy


### PR DESCRIPTION
Line 1849 contains specific hide filter, which is redundant to ##.g1-advertisement from EasyList, with domain(s) spottedlublin.pl FILTER: spottedlublin.pl##.g1-advertisement