### PR TITLE
rni24.eu

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1669,3 +1669,4 @@ baxu.pl##a[href^="https://simpleanalytics.com/”]
 meczlive.pl##a[href="https://www.typ.pl"]
 motohigh.pl##section[id^="text-"] > .mvp-main-box
 wilanownews.pl##.hm-header-sidebar
+rni24.eu##.head-wrap-in


### PR DESCRIPTION
-[rni24.eu](https://rni24.eu/powiat-nizanski-wspiera-szpital-w-walce-z-covid-19/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/rni24.eu.png)