### PR TITLE
purepc.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1669,3 +1669,4 @@ baxu.pl##a[href^="https://simpleanalytics.com/”]
 meczlive.pl##a[href="https://www.typ.pl"]
 motohigh.pl##section[id^="text-"] > .mvp-main-box
 wilanownews.pl##.hm-header-sidebar
+purepc.pl##a[title="KIOXIA"]


### PR DESCRIPTION
-[purepc.pl](https://www.purepc.pl/apple-iphone-12-mini-jednak-nie-bedzie-hitem-kompaktowy-flagowiec-z-niewielkim-wyswietlaczem-dosc-slabo-sie-sprzedaje)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/purepc.pl.png)