### PR TITLE
info112.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1824,3 +1824,4 @@ superportal24.pl##.widget_no_mobile
 rrs24.net##aside[id^="ai_widget-"]
 zkaszub.info##.edd
 losice.info##[id^="adni_"]
+info112.pl###firmy-box-inner


### PR DESCRIPTION
https://info112.pl/2021/01/12/300-gosci-w-hotelu-we-wladyslawowie-wlasciciel-twierdzil-ze-to-turniej-szachowy-zdjecia/

![image](https://user-images.githubusercontent.com/58596052/104440221-5edc1580-5592-11eb-89dd-da176768f4ad.png)
