### PR TITLE
krosno112.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1824,3 +1824,4 @@ superportal24.pl##.widget_no_mobile
 rrs24.net##aside[id^="ai_widget-"]
 zkaszub.info##.edd
 losice.info##[id^="adni_"]
+krosno112.pl##.polecamy + .module-ct


### PR DESCRIPTION
https://krosno112.pl/aktualnosci/inne/item/10098-chore-na-telazjoze-bieszczadzkie-zubry-zostana-odstrzelone-zgode-wydala-gdos.html

![image](https://user-images.githubusercontent.com/58596052/104440709-f8a3c280-5592-11eb-9eca-7afcad4f0faf.png)
