### PR TITLE
rzeszow112.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1077,3 +1077,4 @@ _Banner$image,domain=make-cash.pl
 ||gazetaslezanska.pl^*^jaross-
 ||gazetaslezanska.pl^*^BR_WrocTUW_
 ^banery^$domain=swiatopon.info
+||rzeszow112.pl^*^buz-3.


### PR DESCRIPTION
https://www.rzeszow112.pl/wiadomosci/1863-koronawirus-na-podkarpaciu-sroda-13-01-2020

![image](https://user-images.githubusercontent.com/58596052/104444049-897c9d00-5597-11eb-8c5e-e4d0f9213752.png)
