### PR TITLE
lublin112.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1824,3 +1824,4 @@ superportal24.pl##.widget_no_mobile
 rrs24.net##aside[id^="ai_widget-"]
 zkaszub.info##.edd
 losice.info##[id^="adni_"]
+lublin112.pl###firmy-box-inner


### PR DESCRIPTION
https://www.lublin112.pl/9053-nowe-zakazenia-koronawirusem-w-kraju-493-w-woj-lubelskim-nie-zyje-481-osob-z-infekcja-covid-19/

![image](https://user-images.githubusercontent.com/58596052/104445977-16c0f100-559a-11eb-9a84-0f98ebb0fa91.png)
