### PR TITLE
nadwisla24.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1110,3 +1110,4 @@ _baner.$domain=112malopolska.pl
 _baner.$domain=112wadowice.pl
 ^baner-$domain=infomalopolska.pl
 -reklamowy.$domain=koscian112.pl
+||autorak.com.pl^$subdocument,domain=nadwisla24.pl

--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1879,3 +1879,4 @@ radioandrychow.pl##.mradio-marketing
 firmowy.com.pl##a[target="_blank"] > .opacity2
 budoskop.pl##[id^="mediaContent"]
 koscian112.pl###media_image-3
+nadwisla24.pl##div[class^="g-dyn a-"] a:not([href^="https://nadwisla24.pl/"])


### PR DESCRIPTION
-[nadwisla24.pl](https://nadwisla24.pl/2021/01/09/hit-teatralny-kolacja-dla-glupca-w-czwartek-4-marca-w-stalowej-woli/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/nadwisla24.pl.png)