### PR TITLE
cafesenior.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1732,3 +1732,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+cafesenior.pl##div[data-adslot-id]


### PR DESCRIPTION
-[cafesenior.pl](https://cafesenior.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/cafesenior.pl.png)