### PR TITLE
nadwisla24.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -999,3 +999,4 @@ _reklamy_$domain=chojna24.pl
 ||zyciezamoscia.pl^*^kamienie_small
 ||zyciezamoscia.pl^*^niewygodne2.
 ||zyciezamoscia.pl^*^niezalezna.
+||autorak.com.pl^$subdocument,domain=nadwisla24.pl

--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1732,3 +1732,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+nadwisla24.pl##div[class^="g-dyn a-"] a:not([href^="https://nadwisla24.pl/"])


### PR DESCRIPTION
-[nadwisla24.pl](https://nadwisla24.pl/2021/01/09/hit-teatralny-kolacja-dla-glupca-w-czwartek-4-marca-w-stalowej-woli/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/nadwisla24.pl.png)