### PR TITLE
mazovia24.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1743,3 +1743,6 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+mazovia24.pl##.reklama_onediv a:not([href^="http://www.mazovia24.pl/"])
+mazovia24.pl##.ROTcarousel
+mazovia24.pl##.slides_oneDIV


### PR DESCRIPTION
-[mazovia24.pl](http://www.mazovia24.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/mazovia24.pl.png)