### PR TITLE
okraglemiasto.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1756,3 +1756,4 @@ nowypm.pl##.bnr
 production-manager.pl##.banner-carousel
 tarnowiak.pl###content a[target]
 gazetakolobrzeska.pl##.elementor-image a:not([href*="gazetakolobrzeska.pl"], [href="/"])
+okraglemiasto.pl##.td-a-rec > .td-all-devices


### PR DESCRIPTION
-[okraglemiasto.pl](https://okraglemiasto.pl/ponad-80-tysiecy-trafilo-do-puszek-kolskich-wolontariuszy/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/okraglemiasto.pl.png)