### PR TITLE
slaskiesiemianowice.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1801,3 +1801,4 @@ spottedstarachowice.pl###gkPageContent .custom > p > a[target="_blank"] > img
 sucha24.pl##[id^="bills_in_rotation_"]
 radiovictoria.pl##.herald-txt-module div a
 kurierzurominski.pl##.herald-txt-module
+slaskiesiemianowice.pl##.trzyreklamy


### PR DESCRIPTION
https://slaskiesiemianowice.pl/siemianowice-slaskie-urzednicy-im-bardziej-sie-przed-wirusem-zamykali-tym-bardziej-chorowali/

![image](https://user-images.githubusercontent.com/58596052/107343944-290f4b80-6ac2-11eb-8213-45bc78d7a1c1.png)
