### PR TITLE
niezalezna.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1801,3 +1801,4 @@ spottedstarachowice.pl###gkPageContent .custom > p > a[target="_blank"] > img
 sucha24.pl##[id^="bills_in_rotation_"]
 radiovictoria.pl##.herald-txt-module div a
 kurierzurominski.pl##.herald-txt-module
+niezalezna.pl##div.prenumerata-banner


### PR DESCRIPTION
https://niezalezna.pl/379423-walesa-opublikowal-liste-najwiekszych-szatanow-na-pierwszym-miejscu-prof-cenckiewicz

![image](https://user-images.githubusercontent.com/58596052/107352622-5eb93200-6acc-11eb-9af7-6f8a4a837064.png)
