### PR TITLE
shareinfo.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1075,3 +1075,4 @@ _banerek.$domain=plytkiceramiczne.info.pl
 ^emisje^$domain=stalowemiasto.pl
 ||ifotos.pl^img^$domain=supertydzien.pl
 ||alicdn.com^$image,domain=wlodawa.net
+||contentstream.pl^$domain=shareinfo.pl


### PR DESCRIPTION
https://shareinfo.pl/nie-zyje-aleksander-doba-slynny-polski-podroznik-zmarl-po-zdobyciu-kilimandzaro/

![image](https://user-images.githubusercontent.com/58596052/108990605-61ed1a00-7697-11eb-97e5-cf7f5f0880f7.png)
