### PR TITLE
sport.radiozet.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1889,3 +1889,4 @@ skipol.pl###makler7
 skipol.pl###maklerboczna1
 open.fm##.listAdvSlot
 lubanski.eu##.shailan_banner_widget
+radiozet.pl##.advContainer


### PR DESCRIPTION
-[sport.radiozet.pl](https://sport.radiozet.pl/Pilka-nozna/Premier-League/Liverpool-Chelsea-Transmisja-TV-i-online.-Gdzie-obejrzec-na-zywo)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/sport.radiozet.pl.png)