### PR TITLE
antyradio.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1889,3 +1889,4 @@ skipol.pl###makler7
 skipol.pl###maklerboczna1
 open.fm##.listAdvSlot
 lubanski.eu##.shailan_banner_widget
+antyradio.pl##.advContainer


### PR DESCRIPTION
-[antyradio.pl](https://www.antyradio.pl/Filmy-i-seriale/Filmy/Tom-Holland-nie-potrafil-wrocic-do-roli-Spider-Mana-po-Uncharted-46305)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/antyradio.pl.png)