### PR TITLE
2x45.info

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1889,3 +1889,4 @@ skipol.pl###makler7
 skipol.pl###maklerboczna1
 open.fm##.listAdvSlot
 lubanski.eu##.shailan_banner_widget
+2x45.info##a[href^="https://in.betsson29.com/"]


### PR DESCRIPTION
-[2x45.info](http://www.2x45.info/aktualnosci/65394/info-luquinhas-na-dluzej-w-legii-kucharski-transfer-muciego-mogl-upasc-przez-twittera-klimala-bedzie-wypozyczony-z-celticu/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/2x45.info.png)