### PR TITLE
gramwzielone.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1077,3 +1077,4 @@ _banerek.$domain=plytkiceramiczne.info.pl
 ||alicdn.com^$image,domain=wlodawa.net
 ||skipol.pl^*^watermark_azoty.
 ||ogloszeniarolnicze.com.pl^**^mkw-nowa.
+-baner-$domain=gramwzielone.pl


### PR DESCRIPTION
-[gramwzielone.pl](https://gramwzielone.pl/energia-sloneczna/104915/ceny-paneli-fotowoltaicznch-z-chin-zaczely-rosnac)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/gramwzielone.pl.png)