### PR TITLE
styl.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1878,3 +1878,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+styl.pl##a[onclick^="iwa('trackEvent'"] > img


### PR DESCRIPTION
-[styl.pl](https://www.styl.pl/podroze/news-bergen-miasto-kolorowych-domow,nId,3100269)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/styl.pl.png)