### PR TITLE
viva.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1898,3 +1898,4 @@ polki.pl##div[id^="ecomm-ssr-wrapper-"]
 telekamery.pl##.owl-ads
 purepc.pl##a[href^="/redix.php?"][databx]
 wp.pl##li[data-adv] > div[data-native-adv]
+viva.pl##.ecomm-offer


### PR DESCRIPTION
-[viva.pl](https://viva.pl/ludzie/newsy/ile-i-jak-schudl-filip-chajzer-stare-zdjecia-prezentera-34237-r3/5/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/viva.pl.png)