### PR TITLE
ilewazy.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1898,3 +1898,4 @@ polki.pl##div[id^="ecomm-ssr-wrapper-"]
 telekamery.pl##.owl-ads
 purepc.pl##a[href^="/redix.php?"][databx]
 wp.pl##li[data-adv] > div[data-native-adv]
+ilewazy.pl##.ecomm-offer


### PR DESCRIPTION
-[ilewazy.pl](http://www.ilewazy.pl/porcja-twarozku-domowego-z-ogorkiem-i-koperkiem)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/ilewazy.pl.png)