### PR TITLE
silesiainfotransport.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1898,3 +1898,4 @@ polki.pl##div[id^="ecomm-ssr-wrapper-"]
 telekamery.pl##.owl-ads
 purepc.pl##a[href^="/redix.php?"][databx]
 wp.pl##li[data-adv] > div[data-native-adv]
+silesiainfotransport.pl###media_image-31


### PR DESCRIPTION
-[silesiainfotransport.pl](http://silesiainfotransport.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/silesiainfotransport.pl.png)