### PR TITLE
wiadomoscidebickie.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1924,3 +1924,4 @@ deblinnews.pl##[id^="black-studio-tinymce-"] a[target="_blank"]
 dieroten.pl##a[href^="https://www.iparts.pl/"]
 samnaprawiam.com##a[href^="https://iparts.pl"]
 niebiescy.pl##a[target="_blank"] > img[src^="bilds/"]
+wiadomoscidebickie.pl###media_image-2


### PR DESCRIPTION
-[wiadomoscidebickie.pl](https://wiadomoscidebickie.pl/mazoretki-z-pilzna-znow-na-podium/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/wiadomoscidebickie.pl.png)