### PR TITLE
gazetabialolecka.waw.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1924,3 +1924,4 @@ deblinnews.pl##[id^="black-studio-tinymce-"] a[target="_blank"]
 dieroten.pl##a[href^="https://www.iparts.pl/"]
 samnaprawiam.com##a[href^="https://iparts.pl"]
 niebiescy.pl##a[target="_blank"] > img[src^="bilds/"]
+gazetabialolecka.waw.pl###custom_html-2


### PR DESCRIPTION
-[gazetabialolecka.waw.pl](http://gazetabialolecka.waw.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/gazetabialolecka.waw.pl.png)