### PR TITLE
kaszuby24.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -1936,3 +1936,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+kaszuby24.pl##.td-a-rec


### PR DESCRIPTION
-[kaszuby24.pl](https://kaszuby24.pl)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/kaszuby24.pl.png)