### PR TITLE
rlu24.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1109,3 +1109,4 @@ euslugi.pl##.banners
 ||zyciezamoscia.pl^*^kamienie_small
 ||zyciezamoscia.pl^*^niewygodne2.
 ||zyciezamoscia.pl^*^niezalezna.
+||rlu24.pl^marek2.


### PR DESCRIPTION
https://rlu24.pl/motoryzacja/lubaczow/12617-mazda-6-25l-bose-led-dodatkowe-kola.html

![image](https://user-images.githubusercontent.com/58596052/116970811-e7ed9880-acb8-11eb-9293-eb8240d2c94b.png)
