### PR TITLE
kozaczek.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1109,3 +1109,4 @@ euslugi.pl##.banners
 ||zyciezamoscia.pl^*^kamienie_small
 ||zyciezamoscia.pl^*^niewygodne2.
 ||zyciezamoscia.pl^*^niezalezna.
+kozaczek.pl##iframe[name="hybrid_inimage_ssp_api"]


### PR DESCRIPTION
-[kozaczek.pl](https://www.kozaczek.pl/galeria/omg-ojciec-meghan-markle-dostarczyl-list-do-domu-oprah-winfrey-zdjecia/)

![image](https://raw.githubusercontent.com/adblock-filters/filter-scripts/master/screens/kozaczek.pl.png)