### PR TITLE
biegowe.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1120,3 +1120,5 @@ euslugi.pl##.banners
 ^baner_$domain=radioradom.pl
 ^inline__$domain=e-kg.pl
 ||slotverify.dreamlab.pl^$subdocument,domain=onet.pl
+^banner_$domain=biegowe.pl
+


### PR DESCRIPTION
https://biegowe.pl/2021/05/od-dzisiaj-dozwolone-biegi-w-grupach-po-250-osob-jak-sprawdzic-czy-biegacz-jest-zaszczepiony.html

![Screenshot from 2021-05-28 13-18-33](https://user-images.githubusercontent.com/58596052/119976838-fbd6a280-bfb7-11eb-8152-df71b94404b0.png)
