### PR TITLE
biokurier.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_block.txt
+++ b/easylistpolish/easylistpolish_specific_block.txt
@@ -1120,3 +1120,5 @@ euslugi.pl##.banners
 ^baner_$domain=radioradom.pl
 ^inline__$domain=e-kg.pl
 ||slotverify.dreamlab.pl^$subdocument,domain=onet.pl
+^banner-$domain=biokurier.pl
+


### PR DESCRIPTION
https://biokurier.pl/ekorynek/bio-planet-zadebiutuje-na-warszawskiej-gieldzie/

![Screenshot from 2021-05-28 14-03-19](https://user-images.githubusercontent.com/58596052/119981782-4e1ac200-bfbe-11eb-8ca6-be2f0347c023.png)
