### PR TITLE
dts24.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -2058,3 +2058,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+dts24.pl##a[href^="https://abcekodom.pl/"]


### PR DESCRIPTION
https://www.dts24.pl/trzydziesci-lat-minelo-w-pazdzierniku-do-nowego-sacza-zjedzie-tlum-absolwentow-wyzszej-szkoly-biznesu/

![image](https://user-images.githubusercontent.com/58596052/134959629-18f0aeb3-b3a8-4d9b-926c-0cde3722f048.png)
