### PR TITLE
mciekawostkihistoryczne.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -2058,3 +2058,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+ciekawostkihistoryczne.pl##.placeholderAds


### PR DESCRIPTION
https://ciekawostkihistoryczne.pl/2021/10/06/wojna-piwna-we-wroclawiu/

![image](https://user-images.githubusercontent.com/58596052/136343725-fa46b0a2-b67a-4b75-800b-ae7f7a4ba0b2.png)
