### PR TITLE
gieldykryptowalut.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -2074,3 +2074,5 @@ goral.info.pl##[class^="l-box l-box--"] a[target]
 spozywczetechnologie.pl##.bannergroup
 alarmy.org##.baner750
 o2.pl##div[class$="container"]:not([class*="player"],.npp-container)
+gieldykryptowalut.pl###text-55
+gieldykryptowalut.pl###text-49


### PR DESCRIPTION
https://gieldykryptowalut.pl/binance-przeznaczy-115-mln-na-rozwoj-kryptowalut-w-europie/

![image](https://user-images.githubusercontent.com/58596052/140457717-09a5bf30-bc78-4c64-b78a-302ba25a5db2.png)
