### PR TITLE
trojmiasto.pl adv emptiness

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -2149,3 +2149,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+trojmiasto.pl##.banner-a


### PR DESCRIPTION
https://www.trojmiasto.pl/wiadomosci/Kierowco-zwolnij-przed-kaluza-n162057.html

![image](https://user-images.githubusercontent.com/58596052/149665510-fb9da54a-fab2-49f2-a5d7-5b35e01f6a2a.png)
