### PR TITLE
tygodnikkrag.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -2191,3 +2191,4 @@ stooq.pl##td[width="1"] + td[valign="top"]
 twojezaglebie.pl#?#div:-abp-has(> div > div > a:-abp-contains(ARTYKUŁ SPONSOROWANY))
 dziennikplocki.pl##ul[id^="campaign"]
 wykop.pl#?#li:-abp-has(a[href^="https://www.wykop.pl/paylink/"])
+tygodnikkrag.pl##[class^="a-single a-"]


### PR DESCRIPTION
https://tygodnikkrag.pl/kultura/2022/02/eko-alarm-jeszcze-w-lutym-na-deskach-ndk/

![image](https://user-images.githubusercontent.com/58596052/154318720-39bc02df-38d1-45e6-80be-88d18b768414.png)
