### PR TITLE
A: mediamarkt.pl

### DIFF
--- a/easylistpolish/easylistpolish_specific_hide.txt
+++ b/easylistpolish/easylistpolish_specific_hide.txt
@@ -2195,6 +2195,7 @@ medycyna24.pl##article > .insert--top-offer
 dziennikzachodni.pl,nowiny24.pl##article.contentStream
 allegro.pl##article[data-analytics-view-label^="allegro.advertising.adspremium"]
 allegro.pl##article[data-analytics-view-label^="showSponsoredItems"]
+mediamarkt.pl##article[data-cs-override-id^="mms-sponsored-product-card-"]
 otomoto.pl##article[data-testid="featured-dealer"]
 radio7.pl##aside .a-single
 gorliczanin.pl##aside > section[id^="media_image-"]
@@ -2206,6 +2207,7 @@ nowy-sacz.info##aside#text-6
 walbrzyszek.com##aside.rpre_tlo
 jaw.pl##aside.td_block_template_1 img
 przegladwolski.pl##aside.widget_media_image
+mediamarkt.pl##aside[class="sc-a2fcee8-0 fmYGst"]:has(button[aria-label="Dowiedz się więcej o sponsorowaniu produktów"])
 endurorider.pl##aside[id*="dupermag_ad"]
 rrs24.net##aside[id^="ai_widget-"]
 lubaczow.tv##aside[id^="custom_html-"]
@@ -2506,6 +2508,7 @@ wedkarskisprzet.pl##img[width="150"]
 automotivesuppliers.pl##img[width="370"][height="140"]
 rp.pl##ins[class="adsbygoogle"]
 donald.pl##ins[class^="staticpubads"]
+mediamarkt.pl##li[data-index-number]:has(button[aria-label="Dowiedz się więcej o sponsorowaniu produktów"])
 opowiecie.info##li[id^="bunyad_ads_widget-"]
 thinkapple.pl##li[id^="media_image-"]
 pyrzyce.info##li[id^="text-"] a[target="_blank"]


### PR DESCRIPTION
`mediamarkt.pl##aside[class="sc-a2fcee8-0 fmYGst"]:has(button[aria-label="Dowiedz się więcej o sponsorowaniu produktów"])
mediamarkt.pl##article[data-cs-override-id^="mms-sponsored-product-card-"]` are for `https://mediamarkt.pl/pl/search.html?query=tv%20oled`

`mediamarkt.pl##li[data-index-number]:has(button[aria-label="Dowiedz się więcej o sponsorowaniu produktów"])` is intended for `https://mediamarkt.pl/`